### PR TITLE
Add wheel building and renaming to generate.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Wheel files
+*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 # Wheel files
 *.whl
+
+# temporary generated files
+pyproject.toml

--- a/generate.py
+++ b/generate.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env -S uv run --verbose
+#!/usr/bin/env -S uv run
 
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["setuptools", "toml", "wheel"]
+# dependencies = ["setuptools", "toml", "wheel", "build"]
 # ///
 
 import sys
@@ -47,15 +47,18 @@ def build_wheel():
     subprocess.run([sys.executable, "-m", "build"], check=True)
 
 def rename_wheel():
-    platform_tag = get_platform()
+    platform_tag = get_platform(".")
     # Assuming the wheel file is in the dist directory and has a standard naming convention
     wheel_file = f"dist/metatorch-{TORCH_VERSION}-py3-none-any.whl"
     new_wheel_file = f"dist/metatorch-{TORCH_VERSION}-py3-none-{platform_tag}.whl"
     os.rename(wheel_file, new_wheel_file)
 
 def main() -> None:
+    print("+ Generating pyproject.toml")
     generate_pyproject()
+    print("+ Building wheel")
     build_wheel()
+    print("+ Renaming wheel")
     rename_wheel()
 
 if __name__ == "__main__":

--- a/generate.py
+++ b/generate.py
@@ -8,6 +8,8 @@
 import sys
 import toml
 import subprocess
+import os
+from setuptools.command.bdist_wheel import get_platform
 
 TORCH_VERSION = "2.6.0"
 
@@ -44,12 +46,17 @@ def generate_pyproject():
 def build_wheel():
     subprocess.run([sys.executable, "-m", "build"], check=True)
 
+def rename_wheel():
+    platform_tag = get_platform()
+    # Assuming the wheel file is in the dist directory and has a standard naming convention
+    wheel_file = f"dist/metatorch-{TORCH_VERSION}-py3-none-any.whl"
+    new_wheel_file = f"dist/metatorch-{TORCH_VERSION}-py3-none-{platform_tag}.whl"
+    os.rename(wheel_file, new_wheel_file)
+
 def main() -> None:
     generate_pyproject()
-    # TODO: Build wheel with python -m build
-    # TODO: Rename wheel with platform specific tag using python -m wheel
-    #       You should be able to grab the tag using:
-    #       from setuptools.command.bdist_wheel import get_platform
+    build_wheel()
+    rename_wheel()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add wheel building and renaming functionality to `generate.py`.

* **generate.py**
  - Import `get_platform` from `setuptools.command.bdist_wheel`.
  - Add a call to `build_wheel` in the `main` function.
  - Add a function `rename_wheel` to rename the wheel with platform-specific tag using `os.rename`.
  - Call `rename_wheel` in the `main` function after `build_wheel`.

* **.gitignore**
  - Add `*.whl` to ignore built wheel files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/seemethere/metatorch/pull/1?shareId=edd1d6d9-3711-4187-a1b0-bff453bcbb7d).